### PR TITLE
Move skip release to actual skip release label

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
       "minor": "Version: Minor",
       "patch": "Version: Patch",
       "internal": "Version: Trivial",
-      "documentation": "Docs"
+      "documentation": "Docs",
+      "skip-release": "Skip Release"
     },
     "plugins": [
       "npm",
@@ -24,7 +25,6 @@
     ],
     "skipReleaseLabels": [
       "Version: Trivial",
-      "Skip Release",
       "Docs"
     ]
   }


### PR DESCRIPTION
Just a minor config update to move the `Skip Release` label under `skip-release`. 